### PR TITLE
[#sentry_notification] SentryのWebhookインテグレーションからSlackチャンネルに通知する仕組みを追加

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,7 @@ provider:
     GITHUB_API_TOKEN: ${env:GITHUB_API_TOKEN}
     GITHUB_ORGANIZATION: ${env:GITHUB_ORGANIZATION}
     GITHUB_SPREADSHEET_URL: ${env:GITHUB_SPREADSHEET_URL}
+    SENTRY_NOTIFY_LIST: ${env:SENTRY_NOTIFY_LIST}
   deploymentBucket:
     name: bp-cron-serverless-deployment
 
@@ -81,6 +82,16 @@ functions:
       - {Ref: PythonRequirementsLambdaLayer}
     events:
       - schedule: cron(0 00 10 * ? *)
+
+  # SentryのWebhookをAPIGatewayのエンドポイントで受けてLambdaでSlackに通知する
+  sentry_notification:
+    handler: src/handlers/sentry_notification.job
+    layers:
+      - {Ref: PythonRequirementsLambdaLayer}
+    events:
+      - httpApi:
+          path: /sentry_notification
+          method: post
 
 # Plugins
 plugins:

--- a/src/handlers/sentry_notification.py
+++ b/src/handlers/sentry_notification.py
@@ -1,0 +1,79 @@
+import os
+import logging
+import json
+from urllib.parse import urlparse
+
+from src.utils import slack
+
+logger = logging.getLogger()
+
+
+def get_browser_info(event):
+    browser = event["contexts"]["browser"]
+    if browser is None:
+        return "unknown"
+    return "{name} {type} {version}".format(**browser)
+
+
+def get_os_info(event):
+    client_os = event["contexts"]["client_os"]
+    if client_os is None:
+        return "unknown"
+    return "{name} {type} {version}".format(**client_os)
+
+
+def get_slack_channel_name(sentry_url):
+    notify_list = os.getenv("SENTRY_NOTIFY_LIST")
+    o = urlparse(sentry_url)
+    for w in notify_list.split(","):
+        sentry_organization_name, channel = w.split("#")
+        if sentry_organization_name == o.path.split("/")[2]:
+            return "#" + channel
+
+
+def job(event, context):
+    """SentryのWebhookを受けて環境変数に登録されているSlackチャンネルに通知を飛ばす
+    """
+    logger.info("Start job")
+    body = json.loads(event["body"])
+    event = body["event"]
+
+    channel = get_slack_channel_name(body["url"])
+    if not channel:
+        logger.info("Not found Slack Channel")
+
+    browser_info = get_browser_info(event)
+    os_info = get_os_info(event)
+    title = event["title"] or ""
+    environment = event["environment"] or ""
+    level = event["level"] or ""
+    timestamp = event["timestamp"] or ""
+    attachments = [
+        {
+            "title": title,
+            "title_link": body["url"],
+            "color": "#CE1515",
+            "fields": [
+                {
+                    "title": "Environment",
+                    "value": environment,
+                },
+                {
+                    "title": "Level",
+                    "value": level,
+                },
+                {
+                    "title": "Browser Info",
+                    "value": browser_info,
+                },
+                {
+                    "title": "ClientOS Info",
+                    "value": os_info,
+                },
+            ],
+            "footer": "Send from bp-cron",
+            "ts": timestamp,
+        }
+    ]
+    slack.post_message(channel, "Sentry Notify", attachments=attachments)
+    logger.info("End job")


### PR DESCRIPTION
## 内容

* SentryのWebhookインテグレーションからSlackチャンネルに通知する仕組みを追加

## 実装経緯

* SentryのSlackインテグレーションがDeveloper planだと2022年2月22日に使えなくなるため一時的にWebhookインテグレーションを利用してSlackに通知するように対応した。