### PR TITLE
Stop install sls globally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,6 @@ jobs:
           - v1-dependencies-
     # install Serverless Framework
     - run:
-        name: install-serverless
-        command: sudo npm install -g serverless@2.7.0
-    - run:
         command: npm install
     - save_cache:
         paths:
@@ -61,8 +58,8 @@ jobs:
     - deploy:
         name: Deploy by Serverless Framework
         command: |
-          sls config credentials -k ${AWS_ACCESS_KEY_ID} -s ${AWS_SECRET_ACCESS_KEY} -p aws
-          sls deploy
+          npx sls config credentials -k ${AWS_ACCESS_KEY_ID} -s ${AWS_SECRET_ACCESS_KEY} -p aws
+          npx sls deploy
 workflows:
   test-and-deploy:
     jobs:


### PR DESCRIPTION
* CircleCI の deploy ジョブで 'Cannot run local installation of the Serverless Framework by the outdated global version.' というエラーが出るようになった [1]
* `package.json` で serverless のバージョン管理してるので、そちらを使うように変更してこの問題を解消

[1]: https://app.circleci.com/pipelines/github/beproud/bp-cron/81/workflows/73ff0e0f-5a50-4b7e-ba12-f928041593de/jobs/110